### PR TITLE
Add GitHub Actions Build Status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # XPlaneImGuiPluginTemplate
 
+[![Build Status](https://github.com/1090MHz/XPlaneImGuiPluginTemplate/workflows/Build/badge.svg?branch=main)](https://github.com/1090MHz/XPlaneImGuiPluginTemplate/actions)
+
 A lightweight X-Plane plugin that integrates ImGui for enhanced in-sim user interfaces.
 
 ## Building the Plugin


### PR DESCRIPTION
Shows cross-platform build status for Windows, Linux, and macOS builds.